### PR TITLE
default AMIs for all EC2 regions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,7 @@ validate-ami:
 	pack-ami validate -p ./packer -t ${template}
 
 build-ami:
-	pack-ami build -p ./packer -t ${template} | tee /tmp/build-ami.output
-	@cat /tmp/build-ami.output | tfvar-ami ${template} > ${template)_ami.tfvars
-	@rm -f /tmp/build-ami.output
+	pack-ami build -p ./packer -t ${template}
 
 test:
 	@bash scripts/test.sh

--- a/base_ami.tf
+++ b/base_ami.tf
@@ -1,3 +1,0 @@
-variable "base_ami" {
-  default = "ami-729c5912"
-}

--- a/ecs_ami.tf
+++ b/ecs_ami.tf
@@ -1,3 +1,0 @@
-variable "ecs_ami" {
-  default = "ami-f3985d93"
-}

--- a/main.tf
+++ b/main.tf
@@ -109,6 +109,28 @@ variable "ecs_security_groups" {
   default     = ""
 }
 
+variable "ecs_ami" {
+  description = "The AMI that will be used to launch EC2 instances in the ECS cluster"
+  default     = ""
+}
+
+variable "default_ecs_ami" {
+  description = "A mapping of AWS regions to the default ECS AMIs"
+
+  default = {
+    us-east-1      = "ami-5f3ff932"
+    us-west-1      = "ami-31c08551"
+    us-west-2      = "ami-f3985d93"
+    eu-west-1      = "ami-ab4bd5d8"
+    eu-central-1   = "ami-6c58b103"
+    ap-northeast-1 = "ami-a69d68c7"
+    ap-northeast-2 = "ami-7b2de615"
+    ap-southeast-1 = "ami-550dde36"
+    ap-southeast-2 = "ami-c799b0a4"
+    sa-east-1      = "ami-0274fe6e"
+  }
+}
+
 module "vpc" {
   source = "./vpc"
   name   = "${var.name}"
@@ -164,7 +186,7 @@ module "ecs_cluster" {
   name                 = "default"
   environment          = "${var.environment}"
   vpc_id               = "${module.vpc.id}"
-  image_id             = "${var.ecs_ami}"
+  image_id             = "${coalesce(var.ecs_ami, lookup(var.default_ecs_ami, var.region))}"
   subnet_ids           = "${module.vpc.internal_subnets}"
   key_name             = "${var.key_name}"
   instance_type        = "${var.ecs_instance_type}"

--- a/task/main.tf
+++ b/task/main.tf
@@ -11,7 +11,6 @@
  *
  */
 
-
 /**
  * Required Variables.
  */

--- a/worker/main.tf
+++ b/worker/main.tf
@@ -13,7 +13,6 @@
  *
  */
 
-
 /**
  * Required Variables.
  */


### PR DESCRIPTION
@segmentio/infra 

I made copies of the ECS AMI in all EC2 regions, then changed the terraform config to lookup these AMIs (unless one is explicitly specified).

Please take a look and let me know if this is good to go.