### PR TITLE
default AZ for the region

### DIFF
--- a/defaults/main.tf
+++ b/defaults/main.tf
@@ -1,0 +1,89 @@
+/**
+ * This module is used to set configuration defaults for the AWS infrastructure.
+ * It doesn't provide much value when used on its own because terraform makes it
+ * hard to do dynamic generations of things like subnets, for now it's used as
+ * a helper module for the stack.
+ *
+ * Usage:
+ *
+ *     module "defaults" {
+ *       source = "github.com/segmentio/stack/defaults"
+ *       region = "us-east-1"
+ *       cidr   = "10.0.0.0/16"
+ *     }
+ *
+ */
+
+variable "region" {
+  description = "The AWS region"
+}
+
+variable "cidr" {
+  description = "The CIDR block to provision for the VPC"
+}
+
+variable "default_availability_zones" {
+  description = "A mapping of the default availability zones for each AWS region"
+
+  default = {
+    us-east-1      = "us-east-1a,us-east-1b,us-east-1c,us-east-1e"
+    us-west-1      = "us-west-1a,us-west-1b"
+    us-west-2      = "us-west-2a,us-west-2b,us-west-2c"
+    eu-west-1      = "eu-west-1a,eu-west-1b,eu-west-1c"
+    eu-central-1   = "eu-central-1a,eu-central-1b"
+    ap-southeast-1 = "ap-southeast-1a,ap-southeast-1b"
+    ap-southeast-2 = "ap-southeast-2a,ap-southeast-2b,ap-southeast-2c"
+    ap-northeast-1 = "ap-northeast-1a,ap-northeast-1c"
+    ap-northeast-2 = "ap-northeast-2a,ap-northeast-2c"
+    sa-east-1      = "sa-east-1a,sa-east-1b,sa-east-1c"
+  }
+}
+
+variable "default_ecs_ami" {
+  default = {
+    us-east-1      = "ami-5f3ff932"
+    us-west-1      = "ami-31c08551"
+    us-west-2      = "ami-f3985d93"
+    eu-west-1      = "ami-ab4bd5d8"
+    eu-central-1   = "ami-6c58b103"
+    ap-northeast-1 = "ami-a69d68c7"
+    ap-northeast-2 = "ami-7b2de615"
+    ap-southeast-1 = "ami-550dde36"
+    ap-southeast-2 = "ami-c799b0a4"
+    sa-east-1      = "ami-0274fe6e"
+  }
+}
+
+# http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/enable-access-logs.html#attach-bucket-policy
+variable "default_log_account_ids" {
+  default = {
+    us-east-1      = "127311923021"
+    us-west-2      = "797873946194"
+    us-west-1      = "027434742980"
+    eu-west-1      = "156460612806"
+    eu-central-1   = "054676820928"
+    ap-southeast-1 = "114774131450"
+    ap-northeast-1 = "582318560864"
+    ap-southeast-2 = "783225319266"
+    ap-northeast-2 = "600734575887"
+    sa-east-1      = "507241528517"
+    us-gov-west-1  = "048591011584"
+    cn-north-1     = "638102146993"
+  }
+}
+
+output "availability_zones" {
+  value = "${lookup(var.default_availability_zones, var.region)}"
+}
+
+output "domain_name_servers" {
+  value = "${cidrhost(var.cidr, 2)}"
+}
+
+output "ecs_ami" {
+  value = "${lookup(var.default_ecs_ami, var.region)}"
+}
+
+output "s3_logs_account_id" {
+  value = "${lookup(var.default_log_account_ids, var.region)}"
+}

--- a/defaults/main.tf
+++ b/defaults/main.tf
@@ -22,23 +22,6 @@ variable "cidr" {
   description = "The CIDR block to provision for the VPC"
 }
 
-variable "default_availability_zones" {
-  description = "A mapping of the default availability zones for each AWS region"
-
-  default = {
-    us-east-1      = "us-east-1a,us-east-1b,us-east-1c,us-east-1e"
-    us-west-1      = "us-west-1a,us-west-1b"
-    us-west-2      = "us-west-2a,us-west-2b,us-west-2c"
-    eu-west-1      = "eu-west-1a,eu-west-1b,eu-west-1c"
-    eu-central-1   = "eu-central-1a,eu-central-1b"
-    ap-southeast-1 = "ap-southeast-1a,ap-southeast-1b"
-    ap-southeast-2 = "ap-southeast-2a,ap-southeast-2b,ap-southeast-2c"
-    ap-northeast-1 = "ap-northeast-1a,ap-northeast-1c"
-    ap-northeast-2 = "ap-northeast-2a,ap-northeast-2c"
-    sa-east-1      = "sa-east-1a,sa-east-1b,sa-east-1c"
-  }
-}
-
 variable "default_ecs_ami" {
   default = {
     us-east-1      = "ami-5f3ff932"
@@ -70,10 +53,6 @@ variable "default_log_account_ids" {
     us-gov-west-1  = "048591011584"
     cn-north-1     = "638102146993"
   }
-}
-
-output "availability_zones" {
-  value = "${lookup(var.default_availability_zones, var.region)}"
 }
 
 output "domain_name_servers" {

--- a/dhcp/main.tf
+++ b/dhcp/main.tf
@@ -7,7 +7,7 @@ variable "vpc_id" {
 }
 
 variable "servers" {
-  description = "A coma separated list of the IP addresses of internal DHCP servers"
+  description = "A comma separated list of the IP addresses of internal DHCP servers"
 }
 
 resource "aws_vpc_dhcp_options" "dns_resolver" {

--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ variable "domain_name_servers" {
 }
 
 variable "region" {
-  description = "the AWS region"
+  description = "the AWS region in which resources are created, you must set the availability_zones variable as well if you define this value to something other than the default"
   default     = "us-west-2"
 }
 
@@ -57,7 +57,7 @@ variable "external_subnets" {
 
 variable "availability_zones" {
   description = "a comma-separated list of availability zones, defaults to all AZ of the region, if set to something other than the defaults, both internal_subnets and external_subnets have to be defined as well"
-  default     = ""
+  default     = "us-west-2a,us-west-2b,us-west-2c"
 }
 
 variable "ecs_instance_type" {
@@ -126,7 +126,7 @@ module "vpc" {
   cidr               = "${var.cidr}"
   internal_subnets   = "${var.internal_subnets}"
   external_subnets   = "${var.external_subnets}"
-  availability_zones = "${coalesce(var.availability_zones, module.defaults.availability_zones)}"
+  availability_zones = "${var.availability_zones}"
   environment        = "${var.environment}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -56,8 +56,25 @@ variable "external_subnets" {
 }
 
 variable "availability_zones" {
-  description = "a comma-separated list of availability zones"
-  default     = "us-west-2a,us-west-2b,us-west-2c"
+  description = "a comma-separated list of availability zones, defaults to all AZ of the region"
+  default     = ""
+}
+
+variable "default_availability_zones" {
+  description = "a mapping of the default availability zones for each AWS region"
+
+  default = {
+    us-east-1      = "us-east-1a,us-east-1b,us-east-1c,us-east-1e"
+    us-west-1      = "us-west-1a,us-west-1b"
+    us-west-2      = "us-west-2a,us-west-2b,us-west-2c"
+    eu-west-1      = "eu-west-1a,eu-west-1b,eu-west-1c"
+    eu-central-1   = "eu-central-1a,eu-central-1b"
+    ap-southeast-1 = "ap-southeast-1a,ap-southeast-1b"
+    ap-southeast-2 = "ap-southeast-2a,ap-southeast-2b,ap-southeast-2c"
+    ap-northeast-1 = "ap-northeast-1a,ap-northeast-1c"
+    ap-northeast-2 = "ap-northeast-2a,ap-northeast-2c"
+    sa-east-1      = "sa-east-1a,sa-east-1b,sa-east-1c"
+  }
 }
 
 variable "ecs_instance_type" {
@@ -132,16 +149,13 @@ variable "default_ecs_ami" {
 }
 
 module "vpc" {
-  source = "./vpc"
-  name   = "${var.name}"
-
-  cidr             = "${var.cidr}"
-  internal_subnets = "${var.internal_subnets}"
-  external_subnets = "${var.external_subnets}"
-
-  availability_zones = "${var.availability_zones}"
-
-  environment = "${var.environment}"
+  source             = "./vpc"
+  name               = "${var.name}"
+  cidr               = "${var.cidr}"
+  internal_subnets   = "${var.internal_subnets}"
+  external_subnets   = "${var.external_subnets}"
+  availability_zones = "${coalesce(var.availability_zones, lookup(var.default_availability_zones, var.region))}"
+  environment        = "${var.environment}"
 }
 
 module "security_groups" {

--- a/s3-logs/main.tf
+++ b/s3-logs/main.tf
@@ -4,25 +4,7 @@ variable "name" {
 variable "environment" {
 }
 
-variable "region" {
-}
-
-# http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/enable-access-logs.html#attach-bucket-policy
-variable "log_account_ids" {
-  default = {
-    us-east-1      = "127311923021"
-    us-west-2      = "797873946194"
-    us-west-1      = "027434742980"
-    eu-west-1      = "156460612806"
-    eu-central-1   = "054676820928"
-    ap-southeast-1 = "114774131450"
-    ap-northeast-1 = "582318560864"
-    ap-southeast-2 = "783225319266"
-    ap-northeast-2 = "600734575887"
-    sa-east-1      = "507241528517"
-    us-gov-west-1  = "048591011584"
-    cn-north-1     = "638102146993"
-  }
+variable "account_id" {
 }
 
 resource "template_file" "policy" {
@@ -30,7 +12,7 @@ resource "template_file" "policy" {
 
   vars = {
     bucket     = "${var.name}-${var.environment}-logs"
-    account_id = "${lookup(var.log_account_ids, var.region)}"
+    account_id = "${var.account_id}"
   }
 }
 

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -160,3 +160,8 @@ output "internal_subnets" {
 output "security_group" {
   value = "${aws_vpc.main.default_security_group_id}"
 }
+
+// The list of availability zones of the VPC.
+output "availability_zones" {
+  value = "${join(",", aws_subnet.external.*.availability_zone)}"
+}


### PR DESCRIPTION
@segmentio/infra 

This adds a mapping of default availability zones for each AWS region, that way when a `stack` module is instantiated, only the region can be specified and the config dynamically figures out what AZ to use.

Note that the AZ may be changing from time to time so we'll likely have to edit these values in the future.