### PR TITLE
Refactor to support Terraform 0.7

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 
 dependencies:
   override:
-    - sudo curl -L# https://releases.hashicorp.com/terraform/0.6.16/terraform_0.6.16_linux_amd64.zip -o /usr/local/bin/tf.zip
+    - sudo curl -L# https://releases.hashicorp.com/terraform/0.7.0/terraform_0.7.0_linux_amd64.zip -o /usr/local/bin/tf.zip
     - cd /usr/local/bin && sudo unzip tf.zip
 
 test:

--- a/ecs-cluster/main.tf
+++ b/ecs-cluster/main.tf
@@ -14,12 +14,12 @@
  *        name                 = "cdn"
  *        vpc_id               = "vpc-id"
  *        image_id             = "ami-id"
- *        subnet_ids           = "1,2"
+ *        subnet_ids           = ["1" ,"2"]
  *        key_name             = "ssh-key"
  *        security_groups      = "1,2"
  *        iam_instance_profile = "id"
  *        region               = "us-west-2"
- *        availability_zones   = "a,b"
+ *        availability_zones   = ["a", "b"]
  *        instance_type        = "t2.small"
  *      }
  *
@@ -42,7 +42,8 @@ variable "image_id" {
 }
 
 variable "subnet_ids" {
-  description = "Comma separated list of subnet IDs"
+  description = "List of subnet IDs"
+  type        = "list"
 }
 
 variable "key_name" {
@@ -62,7 +63,8 @@ variable "region" {
 }
 
 variable "availability_zones" {
-  description = "Comma separated list of AZs"
+  description = "List of AZs"
+  type        = "list"
 }
 
 variable "instance_type" {
@@ -200,8 +202,8 @@ resource "aws_launch_configuration" "main" {
 resource "aws_autoscaling_group" "main" {
   name = "${var.name}"
 
-  availability_zones   = ["${split(",", var.availability_zones)}"]
-  vpc_zone_identifier  = ["${split(",", var.subnet_ids)}"]
+  availability_zones   = ["${var.availability_zones}"]
+  vpc_zone_identifier  = ["${var.subnet_ids}"]
   launch_configuration = "${aws_launch_configuration.main.id}"
   min_size             = "${var.min_size}"
   max_size             = "${var.max_size}"

--- a/main.tf
+++ b/main.tf
@@ -46,18 +46,18 @@ variable "cidr" {
 }
 
 variable "internal_subnets" {
-  description = "a comma-separated list of CIDRs for internal subnets in your VPC, must be set if the cidr variable is defined, needs to have as many elements as there are availability zones"
-  default     = "10.30.0.0/19,10.30.64.0/19,10.30.128.0/19"
+  description = "a list of CIDRs for internal subnets in your VPC, must be set if the cidr variable is defined, needs to have as many elements as there are availability zones"
+  default     = ["10.30.0.0/19" ,"10.30.64.0/19", "10.30.128.0/19"]
 }
 
 variable "external_subnets" {
-  description = "a comma-separated list of CIDRs for external subnets in your VPC, must be set if the cidr variable is defined, needs to have as many elements as there are availability zones"
-  default     = "10.30.32.0/20,10.30.96.0/20,10.30.160.0/20"
+  description = "a list of CIDRs for external subnets in your VPC, must be set if the cidr variable is defined, needs to have as many elements as there are availability zones"
+  default     = ["10.30.32.0/20", "10.30.96.0/20", "10.30.160.0/20"]
 }
 
 variable "availability_zones" {
   description = "a comma-separated list of availability zones, defaults to all AZ of the region, if set to something other than the defaults, both internal_subnets and external_subnets have to be defined as well"
-  default     = "us-west-2a,us-west-2b,us-west-2c"
+  default     = ["us-west-2a", "us-west-2b", "us-west-2c"]
 }
 
 variable "bastion_instance_type" {
@@ -159,7 +159,7 @@ module "bastion" {
   instance_type   = "${var.bastion_instance_type}"
   security_groups = "${module.security_groups.external_ssh},${module.security_groups.internal_ssh}"
   vpc_id          = "${module.vpc.id}"
-  subnet_id       = "${element(split(",",module.vpc.external_subnets), 0)}"
+  subnet_id       = "${element(module.vpc.external_subnets, 0)}"
   key_name        = "${var.key_name}"
   environment     = "${var.environment}"
 }


### PR DESCRIPTION
I wanted to start working on Terraform 0.7  #conversion, so I made a small set of changes, only refactoring to lists for a few variables (internal subnets, external subnets and availability zones).

I am trying to gauge interest in converting more of the stack automation over to Terraform 0.7 to use data sources, and native lists/maps where possible.

I wasn't sure if this was desirable or not, but figured I would test the waters.  