### PR TITLE
Add rtb outputs

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -485,6 +485,8 @@
 | internal_subnets | A comma-separated list of subnet IDs. |
 | security_group | The default VPC security group ID. |
 | availability_zones | The list of availability zones of the VPC. |
+| internal_rtb_id | The internal route table ID. |
+| external_rtb_id | The external route table ID. |
 
 # web-service
 

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -165,3 +165,13 @@ output "security_group" {
 output "availability_zones" {
   value = "${join(",", aws_subnet.external.*.availability_zone)}"
 }
+
+// The internal route table ID.
+output "internal_rtb_id" {
+  value = "${aws_route_table.internal.id}"
+}
+
+// The external route table ID.
+output "external_rtb_id" {
+  value = "${aws_route_table.external.id}"
+}


### PR DESCRIPTION
This came up when we needed to add custom peering to VPC connections inside the stack. By adding these as outputs we can now associate `aws_route` resources with them.