### PR TITLE
vpc: split routes

### DIFF
--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -97,28 +97,31 @@ resource "aws_subnet" "external" {
 resource "aws_route_table" "external" {
   vpc_id = "${aws_vpc.main.id}"
 
-  route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.main.id}"
-  }
-
   tags {
     Name = "${var.name}-external-001"
   }
+}
+
+resource "aws_route" "external" {
+  route_table_id         = "${aws_route_table.external.id}"
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = "${aws_internet_gateway.main.id}"
 }
 
 resource "aws_route_table" "internal" {
   count  = "${length(compact(split(",", var.internal_subnets)))}"
   vpc_id = "${aws_vpc.main.id}"
 
-  route {
-    cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = "${element(aws_nat_gateway.main.*.id, count.index)}"
-  }
-
   tags {
     Name = "${var.name}-${format("internal-%03d", count.index+1)}"
   }
+}
+
+resource "aws_route" "internal" {
+  count                  = "${length(compact(split(",", var.internal_subnets)))}"
+  route_table_id         = "${element(aws_route_table.internal.*.id, count.index)}"
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = "${element(aws_nat_gateway.main.*.id, count.index)}"
 }
 
 /**


### PR DESCRIPTION
This commit preserves the same behavior around stack, but instead
allows us to define route associations outside of the stack itself
and still use the VPC module.

It's due to a known ordering issue in Terraform

https://www.terraform.io/docs/providers/aws/r/route.html

@achille-roussel @yields 