### PR TITLE
expose route table ids to root stack module

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -52,6 +52,8 @@
 | external_elb | Security group for external ELBs. |
 | internal_subnets | Comma separated list of internal subnet IDs. |
 | external_subnets | Comma separated list of external subnet IDs. |
+| internal_route_tables | Comma separated list of internal route table IDs. |
+| external_route_table | The external route table ID. |
 | iam_role | ECS Service IAM role. |
 | log_bucket_id | S3 bucket ID for ELB logs. |
 | domain_name | The internal domain name, e.g "stack.local". |
@@ -572,4 +574,3 @@
 | desired_count | The desired count | `1` | no |
 | memory | The number of MiB of memory to reserve for the container | `512` | no |
 | cpu | The number of cpu units to reserve for the container | `512` | no |
-

--- a/docs.md
+++ b/docs.md
@@ -53,7 +53,7 @@
 | internal_subnets | Comma separated list of internal subnet IDs. |
 | external_subnets | Comma separated list of external subnet IDs. |
 | internal_route_tables | Comma separated list of internal route table IDs. |
-| external_route_table | The external route table ID. |
+| external_route_tables | The external route table ID. |
 | iam_role | ECS Service IAM role. |
 | log_bucket_id | S3 bucket ID for ELB logs. |
 | domain_name | The internal domain name, e.g "stack.local". |

--- a/main.tf
+++ b/main.tf
@@ -292,3 +292,13 @@ output "vpc_id" {
 output "ecs_cluster_security_group_id" {
   value = "${module.ecs_cluster.security_group_id}"
 }
+
+// Comma separated list of internal route table IDs.
+output "internal_route_tables" {
+  value = "${module.vpc.internal_rtb_id}"
+}
+
+// The external route table ID.
+output "external_route_table" {
+  value = "${module.vpc.external_rtb_id}"
+}

--- a/main.tf
+++ b/main.tf
@@ -299,6 +299,6 @@ output "internal_route_tables" {
 }
 
 // The external route table ID.
-output "external_route_table" {
+output "external_route_tables" {
   value = "${module.vpc.external_rtb_id}"
 }


### PR DESCRIPTION
The route table IDs are already  exposed by the VPC module.

This way they are exposed by the root module and we can add routes to the tables.