### PR TITLE
Prevent resource.aws_rds_cluster_instance.cluster_instances from forcing a new resource on every apply.

### DIFF
--- a/rds-cluster/main.tf
+++ b/rds-cluster/main.tf
@@ -111,6 +111,7 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   count                = "${var.instance_count}"
   db_subnet_group_name = "${aws_db_subnet_group.main.id}"
   cluster_identifier   = "${aws_rds_cluster.main.id}"
+  identifier           = "${aws_rds_cluster.main.id}-instance${count.index}"
   publicly_accessible  = "${var.publicly_accessible}"
   instance_class       = "${var.instance_type}"
 }


### PR DESCRIPTION
This PR adds an `identifier` argument to `resource.aws_rds_cluster_instance.cluster_instances` so that it doesn't force a new resource when it is unchanged.

I'm submitting it because any time I'd run `terraform plan` or `terraform apply`, I'd encounter something like:

```
-/+ module.rds_cluster.aws_rds_cluster_instance.cluster_instances
# ...
      identifier:              "terraform-201612151453509179669117gs" => "" (forces new resource)
# ...
```