### PR TITLE
#77 use name variable to join specific ecs-cluster

### DIFF
--- a/ecs-cluster/files/cloud-config.yml.tpl
+++ b/ecs-cluster/files/cloud-config.yml.tpl
@@ -5,5 +5,6 @@ bootcmd:
   - echo 'SERVER_REGION=${region}' >> /etc/environment
 
   - mkdir -p /etc/ecs
+  - echo 'ECS_CLUSTER=${name}' >> /etc/ecs/ecs.config
   - echo 'ECS_ENGINE_AUTH_TYPE=${docker_auth_type}' >> /etc/ecs/ecs.config
   - echo 'ECS_ENGINE_AUTH_DATA=${docker_auth_data}' >> /etc/ecs/ecs.config


### PR DESCRIPTION
Fixes #77 by using the name variable to join a specific ecs-cluster.  This is accomplished by setting the ECS_CLUSTER environment variable.