### PR TITLE
#79 fixes ecs-cluster cloud-init yaml issues by putting sequence on new line

### DIFF
--- a/ecs-cluster/files/cloud-config.yml.tpl
+++ b/ecs-cluster/files/cloud-config.yml.tpl
@@ -6,4 +6,5 @@ bootcmd:
 
   - mkdir -p /etc/ecs
   - echo 'ECS_ENGINE_AUTH_TYPE=${docker_auth_type}' >> /etc/ecs/ecs.config
-  - echo 'ECS_ENGINE_AUTH_DATA=${docker_auth_data}' >> /etc/ecs/ecs.config
+  - >
+    echo 'ECS_ENGINE_AUTH_DATA=${docker_auth_data}' >> /etc/ecs/ecs.config


### PR DESCRIPTION
This fixes #79 by putting the docker_auth_data sequence from the ecs-cluster cloud-init template on a new line to avoid yaml parsing issues.