### PR TITLE
Add determinstic rds cluster instance identifier

### DIFF
--- a/rds-cluster/main.tf
+++ b/rds-cluster/main.tf
@@ -118,6 +118,9 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   cluster_identifier   = "${aws_rds_cluster.main.id}"
   publicly_accessible  = "${var.publicly_accessible}"
   instance_class       = "${var.instance_type}"
+
+  # need a deterministic identifier or terraform will force a new resource every apply
+  identifier = "${aws_rds_cluster.main.id}-${count.index}"
 }
 
 resource "aws_rds_cluster" "main" {


### PR DESCRIPTION
Without specifying an identifier on cluster instances, terraform thinks it needs to destroy and recreate them every apply (which causes an outage). Just number the instances by index.

https://www.terraform.io/docs/providers/aws/r/rds_cluster_instance.html#identifier

@achille-roussel 

`identifier:                 "terraform-0004fddae8b852687e9e685cad" => "" (forces new resource)`