### PR TITLE
include nested terraform modules in tests

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-modules=$(ls -1 */*.tf | xargs -I % dirname %)
+modules=$(find -mindepth 2 -name *.tf -printf '%P\n' | xargs -I % dirname %)
 
 (terraform validate . && echo "√ stack") || exit 1
 


### PR DESCRIPTION
This PR fixes #85 by changing the expression used to find Terraform files for the purposes of testing.  It will now include Terraform files within nested Modules.

This is an example of the output:

- bastion
- defaults
- dhcp
- dns
- ecs-cluster
- elb
- iam-role
- iam-user
- rds-cluster
- s3-logs
- security-groups
- service
- task
- vpc
- web-service/elb
- web-service
- worker

This brings in the nested module _web-service/elb_.