### PR TITLE
variable for log driver on tasks

### DIFF
--- a/task/main.tf
+++ b/task/main.tf
@@ -62,6 +62,11 @@ variable "memory" {
   default     = 512
 }
 
+variable "log_driver" {
+  description = "The log driver to use use for the container"
+  default     = "journald"
+}
+
 /**
  * Resources.
  */
@@ -90,7 +95,7 @@ resource "aws_ecs_task_definition" "main" {
     "entryPoint": ${var.entry_point},
     "mountPoints": [],
     "logConfiguration": {
-      "logDriver": "journald",
+      "logDriver": "${var.log_driver}",
       "options": {
         "tag": "${var.name}"
       }


### PR DESCRIPTION
related to #77. if you use the ami provided by aws ecs, the `journald` log driver does not exist. this change allows you to set one of the others, for example `syslog`.