### PR TITLE
RDS: add database + username config

### DIFF
--- a/rds/main.tf
+++ b/rds/main.tf
@@ -1,5 +1,5 @@
 variable "name" {
-  description = "RDS name and Postgres username"
+  description = "RDS instance name"
 }
 
 variable "engine" {
@@ -15,6 +15,16 @@ variable "engine_version" {
 variable "port" {
   description = "Port for database to listen on"
   default     = 5432
+}
+
+variable "database" {
+  description = "The database name for the RDS instance (if not specified, `var.name` will be used)"
+  default     = ""
+}
+
+variable "username" {
+  description = "The username for the RDS instance (if not specified, `var.name` will be used)"
+  default     = ""
 }
 
 variable "password" {
@@ -130,10 +140,10 @@ resource "aws_db_instance" "main" {
   # Database
   engine         = "${var.engine}"
   engine_version = "${var.engine_version}"
-  username       = "${var.name}"
+  username       = "${coalesce(var.username, var.name)}"
   password       = "${var.password}"
   multi_az       = "${var.multi_az}"
-  name           = "${var.name}"
+  name           = "${coalesce(var.database, var.name)}"
 
   # Backups / maintenance
   backup_retention_period = "${var.backup_retention_period}"


### PR DESCRIPTION
This adds some new optional input variables for the `rds` module:

 - `database`: the database name
 - `username`: the username used for auth

Both of these values are currently set in RDS using `name`, which is a nice default but not especially flexible. It puts a lot of stuttering into the DSN and can be a little verbose when your top-level identifier is namespaced already.

Using a name like `lambda-warehouses` leads to an output `addr` that looks like:

```
postgres://lambda-warehouses:<PASS>@<HOST>/lambda-warehouses
```

(note that `<HOST>` will also contain `lambda-warehouses`, making it appear a total of 3 times)

This PR allows something a bit more clean like:

```
postgres://segment:<PASS>@<HOST>/public
```

Admittedly, this is mostly aesthetic, but I don't think it's unreasonable to want to set this configuration yourself. (and perhaps there are non-aesthetic use-cases I'm just not thinking of)