### PR TITLE
rds-cluster: use postgres default port

### DIFF
--- a/rds-cluster/main.tf
+++ b/rds-cluster/main.tf
@@ -73,7 +73,7 @@ variable "dns_name" {
 
 variable "port" {
   description = "The port at which the database listens for incoming connections"
-  default     = 3306
+  default     = 5432
 }
 
 variable "skip_final_snapshot" {


### PR DESCRIPTION
not sure where the 3306 came from