### PR TITLE
Enable web-service module to track latest ecs task revision

### DIFF
--- a/web-service/main.tf
+++ b/web-service/main.tf
@@ -143,6 +143,9 @@ resource "aws_ecs_service" "main" {
   deployment_minimum_healthy_percent = "${var.deployment_minimum_healthy_percent}"
   deployment_maximum_percent         = "${var.deployment_maximum_percent}"
 
+  # Track the latest ACTIVE revision
+  task_definition = "${module.task.name}:${max("${module.task.revision}", "${data.aws_ecs_task_definition.task.revision}")}"
+
   load_balancer {
     elb_name       = "${module.elb.id}"
     container_name = "${module.task.name}"
@@ -152,6 +155,10 @@ resource "aws_ecs_service" "main" {
   lifecycle {
     create_before_destroy = true
   }
+}
+
+data "aws_ecs_task_definition" "task" {
+  task_definition = "${module.task.name}"
 }
 
 module "task" {


### PR DESCRIPTION
This PR adds an `aws_ecs_task_definition` data source which enables the `aws_ecs_service` to track the latest revision, which may no longer be in sync with Terraform state. Fixes #4 