### PR TITLE
Fixes #108:Add environment tag to VPC module

### DIFF
--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -77,7 +77,8 @@ resource "aws_subnet" "internal" {
   count             = "${length(var.internal_subnets)}"
 
   tags {
-    Name = "${var.name}-${format("internal-%03d", count.index+1)}"
+    Name        = "${var.name}-${format("internal-%03d", count.index+1)}"
+    Environment = "${var.environment}"
   }
 }
 
@@ -89,7 +90,8 @@ resource "aws_subnet" "external" {
   map_public_ip_on_launch = true
 
   tags {
-    Name = "${var.name}-${format("external-%03d", count.index+1)}"
+    Name        = "${var.name}-${format("external-%03d", count.index+1)}"
+    Environment = "${var.environment}"
   }
 }
 
@@ -101,7 +103,8 @@ resource "aws_route_table" "external" {
   vpc_id = "${aws_vpc.main.id}"
 
   tags {
-    Name = "${var.name}-external-001"
+    Name        = "${var.name}-external-001"
+    Environment = "${var.environment}"
   }
 }
 
@@ -116,7 +119,8 @@ resource "aws_route_table" "internal" {
   vpc_id = "${aws_vpc.main.id}"
 
   tags {
-    Name = "${var.name}-${format("internal-%03d", count.index+1)}"
+    Name        = "${var.name}-${format("internal-%03d", count.index+1)}"
+    Environment = "${var.environment}"
   }
 }
 


### PR DESCRIPTION
Add environment tag to `aws_route_table.internal`, `aws_route_table.external`, `aws_subnet.internal`, `aws_subnet.external` 