### PR TITLE
Use role instead of roles (deprecated)

### DIFF
--- a/iam-role/main.tf
+++ b/iam-role/main.tf
@@ -97,7 +97,7 @@ EOF
 resource "aws_iam_instance_profile" "default_ecs" {
   name  = "ecs-instance-profile-${var.name}-${var.environment}"
   path  = "/"
-  roles = ["${aws_iam_role.default_ecs_role.name}"]
+  role  = "${aws_iam_role.default_ecs_role.name}"
 }
 
 output "default_ecs_role_id" {


### PR DESCRIPTION
> WARNING: This is deprecated since [version 0.9.3 (April 12, 2017)](https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md#093-april-12-2017), as >= 2 roles are not possible. See [issue #11575](https://github.com/hashicorp/terraform/issues/11575).

https://www.terraform.io/docs/providers/aws/r/iam_instance_profile.html#roles