### PR TITLE
feat(rds): fix addr output variable to use engine as scheme, add url output that includes db suffix

### DIFF
--- a/rds/main.tf
+++ b/rds/main.tf
@@ -163,5 +163,9 @@ resource "aws_db_instance" "main" {
 }
 
 output "addr" {
-  value = "postgres://${aws_db_instance.main.username}:${aws_db_instance.main.password}@${aws_db_instance.main.endpoint}"
+  value = "${aws_db_instance.main.engine}://${aws_db_instance.main.username}:${aws_db_instance.main.password}@${aws_db_instance.main.endpoint}"
+}
+
+output "url" {
+  value = "${aws_db_instance.main.engine}://${aws_db_instance.main.username}:${aws_db_instance.main.password}@${aws_db_instance.main.endpoint}/${aws_db_instance.main.database}"
 }


### PR DESCRIPTION
This change allows `module.rds.addr` to be used as-is, whereas now you need to append the `/db` suffix. In addition, this now supports other engines besides `postgres` and puts them in place of the scheme. (a needed fix)

Since this is a breaking change, I'm not sure what the best release strategy is. Updating post-change is not serious, you just remove the `/db` suffix where you were adding it manually.