### PR TITLE
fix(rds): use rds name output, as database does not exist

### DIFF
--- a/rds/main.tf
+++ b/rds/main.tf
@@ -167,5 +167,5 @@ output "addr" {
 }
 
 output "url" {
-  value = "${aws_db_instance.main.engine}://${aws_db_instance.main.username}:${aws_db_instance.main.password}@${aws_db_instance.main.endpoint}/${aws_db_instance.main.database}"
+  value = "${aws_db_instance.main.engine}://${aws_db_instance.main.username}:${aws_db_instance.main.password}@${aws_db_instance.main.endpoint}/${aws_db_instance.main.name}"
 }


### PR DESCRIPTION
I introduced a bug in #128 for the new `url` output for the `rds` module. I mistakenly used `database`, but the module exports `name` instead. This caused weird failures downstream that didn't appear related to RDS.