### PR TITLE
added log driver for modules using task

### DIFF
--- a/service/main.tf
+++ b/service/main.tf
@@ -121,6 +121,11 @@ variable "deployment_maximum_percent" {
   default     = 200
 }
 
+variable "log_driver" {
+  description = "The log driver to use use for the container"
+  default     = "journald"
+}
+
 /**
  * Resources.
  */
@@ -155,6 +160,7 @@ module "task" {
   env_vars      = "${var.env_vars}"
   memory        = "${var.memory}"
   cpu           = "${var.cpu}"
+  log_driver    = "${var.log_driver}"
 
   ports = <<EOF
   [

--- a/web-service/main.tf
+++ b/web-service/main.tf
@@ -130,6 +130,11 @@ variable "deployment_maximum_percent" {
   default     = 200
 }
 
+variable "log_driver" {
+  description = "The log driver to use use for the container"
+  default     = "journald"
+}
+
 /**
  * Resources.
  */
@@ -164,6 +169,7 @@ module "task" {
   env_vars      = "${var.env_vars}"
   memory        = "${var.memory}"
   cpu           = "${var.cpu}"
+  log_driver    = "${var.log_driver}"
 
   ports = <<EOF
   [

--- a/worker/main.tf
+++ b/worker/main.tf
@@ -78,6 +78,11 @@ variable "deployment_maximum_percent" {
   default     = 200
 }
 
+variable "log_driver" {
+  description = "The log driver to use use for the container"
+  default     = "journald"
+}
+
 /**
  * Resources.
  */
@@ -105,4 +110,5 @@ module "task" {
   env_vars      = "${var.env_vars}"
   memory        = "${var.memory}"
   cpu           = "${var.cpu}"
+  log_driver    = "${var.log_driver}"
 }


### PR DESCRIPTION
Related to #87

Previously, I didn't use any of the modules that used the task module, now I need to :)

This should be a backwards compatible change.