### PR TITLE
Add final_snapshot_identifier to `rds`

### DIFF
--- a/rds/main.tf
+++ b/rds/main.tf
@@ -146,10 +146,11 @@ resource "aws_db_instance" "main" {
   name           = "${coalesce(var.database, var.name)}"
 
   # Backups / maintenance
-  backup_retention_period = "${var.backup_retention_period}"
-  backup_window           = "${var.backup_window}"
-  maintenance_window      = "${var.maintenance_window}"
-  apply_immediately       = "${var.apply_immediately}"
+  backup_retention_period   = "${var.backup_retention_period}"
+  backup_window             = "${var.backup_window}"
+  maintenance_window        = "${var.maintenance_window}"
+  apply_immediately         = "${var.apply_immediately}"
+  final_snapshot_identifier = "${var.name}-finalsnapshot"
 
   # Hardware
   instance_class    = "${var.instance_class}"


### PR DESCRIPTION
This allows `rds` resources to be destroyed. Currently, destroys fail with an error because we haven't specificed a name for the final snapshot.

`rds-cluster` has this already.