### PR TITLE
Add ssh security group attributes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -329,3 +329,13 @@ output "internal_route_tables" {
 output "external_route_tables" {
   value = "${module.vpc.external_rtb_id}"
 }
+
+// The external ssh security group ID.
+output "external_ssh" {
+  value = "${module.security_groups.external_ssh}"
+}
+
+// The internal ssh security group ID.
+output "internal_ssh" {
+  value = "${module.security_groups.internal_ssh}"
+}


### PR DESCRIPTION
This PR adds `internal_ssh` and `external_ssh` attributes to Stack.  This makes it simple to grant access to resources within the VPC via ssh tunneling through the bastion.