### PR TITLE
Assign IPv6 block when creating VPC.

### DIFF
--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -31,9 +31,10 @@ variable "name" {
  */
 
 resource "aws_vpc" "main" {
-  cidr_block           = "${var.cidr}"
-  enable_dns_support   = true
-  enable_dns_hostnames = true
+  cidr_block                       = "${var.cidr}"
+  enable_dns_support               = true
+  enable_dns_hostnames             = true
+  assign_generated_ipv6_cidr_block = true
 
   tags {
     Name        = "${var.name}"
@@ -154,6 +155,10 @@ resource "aws_route_table_association" "external" {
 // The VPC ID
 output "id" {
   value = "${aws_vpc.main.id}"
+}
+
+output "ipv6_cidr_block" {
+  value = "${aws_vpc.main.ipv6_cidr_block}"
 }
 
 // A comma-separated list of subnet IDs.


### PR DESCRIPTION
I can't find any reason why, when creating a VPC, we shouldn't assign a IPv6 block when creating the resource. If no gateway is assigned, my understanding is the addresses are unreachable so there isn't a security implication. Any discussion appreciated! 
