### PR TITLE
feat(vpc): Optionally use NAT instances instead of NAT gateways

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -155,12 +155,16 @@ traffic in and out of the different subnets. The Stack terraform will automatica
 
 Traffic from each internal subnet to the outside world will run through the associated NAT gateway.
 
+Alternatively, setting the `use_nat_instances` VPC module variable to true, will use [EC2 NAT instances][nat-instances] instead of the NAT gateway. NAT instances cost less than the NAT gateway, can be shutdown when not in use, and may be preferred in development environments. By default, NAT instances will not use [Elastic IPs][elastic-ip] to avoid a small hourly charge if the NAT instances are not running full time. To use Elastic IPs for the NAT instances, set the `use_eip_with_nat_instances` VPC module variable to true.
+
 For further reading, check out these sources:
 
 - [Recommended Address Space](http://serverfault.com/questions/630022/what-is-the-recommended-cidr-when-creating-vpc-on-aws)
 - [Practical VPC Design](https://medium.com/aws-activate-startup-blog/practical-vpc-design-8412e1a18dcc)
 
 [nat-gateway]: http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-nat-gateway.html
+[nat-instances]: http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_NAT_Instance.html
+[elastic-ip]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html
 
 ### Instances
 

--- a/docs.md
+++ b/docs.md
@@ -44,6 +44,10 @@ Usage:
 | cidr | the CIDR block to provision for the VPC, if set to something other than the default, both internal_subnets and external_subnets have to be defined as well | `10.30.0.0/16` | no |
 | internal_subnets | a list of CIDRs for internal subnets in your VPC, must be set if the cidr variable is defined, needs to have as many elements as there are availability zones | `<list>` | no |
 | external_subnets | a list of CIDRs for external subnets in your VPC, must be set if the cidr variable is defined, needs to have as many elements as there are availability zones | `<list>` | no |
+| use_nat_instances | use NAT EC2 instances instead of the NAT gateway service | `false` | no |
+| use_eip_with_nat_instances | use Elastic IPs with NAT instances if `use_nat_instances` is true | `false` | no |
+| nat_instance_type | the EC2 instance type for NAT instances if `use_nat_instances` is true | `t2.nano` | no |
+| nat_instance_ssh_key_name | the name of the ssh key to use with NAT instances if `use_nat_instances` is true | "" | no |
 | availability_zones | a comma-separated list of availability zones, defaults to all AZ of the region, if set to something other than the defaults, both internal_subnets and external_subnets have to be defined as well | `<list>` | no |
 | bastion_instance_type | Instance type for the bastion | `t2.micro` | no |
 | ecs_cluster_name | the name of the cluster, if not specified the variable name will be used | `` | no |

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -265,6 +265,11 @@ output "id" {
   value = "${aws_vpc.main.id}"
 }
 
+// The VPC CIDR
+output "cidr_block" {
+  value = "${aws_vpc.main.cidr_block}"
+}
+
 // A comma-separated list of subnet IDs.
 output "external_subnets" {
   value = ["${aws_subnet.external.*.id}"]

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -26,6 +26,41 @@ variable "name" {
   default     = "stack"
 }
 
+variable "use_nat_instances" {
+  description = "If true, use EC2 NAT instances instead of the AWS NAT gateway service."
+  default     = false
+}
+
+variable "nat_instance_type" {
+  description = "Only if use_nat_instances is true, which EC2 instance type to use for the NAT instances."
+  default     = "t2.nano"
+}
+
+variable "use_eip_with_nat_instances" {
+  description = "Only if use_nat_instances is true, whether to assign Elastic IPs to the NAT instances. IF this is set to false, NAT instances use dynamically assigned IPs."
+  default     = false
+}
+
+# This data source returns the newest Amazon NAT instance AMI
+data "aws_ami" "nat_ami" {
+  most_recent = true
+
+  filter {
+    name   = "owner-alias"
+    values = ["amazon"]
+  }
+
+  filter {
+    name   = "name"
+    values = ["amzn-ami-vpc-nat*"]
+  }
+}
+
+variable "nat_instance_ssh_key_name" {
+  description = "Only if use_nat_instance is true, the optional SSH key-pair to assign to NAT instances."
+  default     = ""
+}
+
 /**
  * VPC
  */
@@ -55,15 +90,81 @@ resource "aws_internet_gateway" "main" {
 }
 
 resource "aws_nat_gateway" "main" {
-  count         = "${length(var.internal_subnets)}"
+  # Only create this if not using NAT instances.
+  count         = "${(1 - var.use_nat_instances) * length(var.internal_subnets)}"
   allocation_id = "${element(aws_eip.nat.*.id, count.index)}"
   subnet_id     = "${element(aws_subnet.external.*.id, count.index)}"
   depends_on    = ["aws_internet_gateway.main"]
 }
 
 resource "aws_eip" "nat" {
-  count = "${length(var.internal_subnets)}"
-  vpc   = true
+  # Create these only if:
+  # NAT instances are used and Elastic IPs are used with them,
+  # or if the NAT gateway service is used (NAT instances are not used).
+  count = "${signum((var.use_nat_instances * var.use_eip_with_nat_instances) + (var.use_nat_instances == 0 ? 1 : 0)) * length(var.internal_subnets)}"
+
+  vpc = true
+}
+
+resource "aws_security_group" "nat_instances" {
+  # Create this only if using NAT instances, vs. the NAT gateway service.
+  count       = "${0 + var.use_nat_instances}"
+  name        = "nat"
+  description = "Allow traffic from clients into NAT instances"
+
+  ingress {
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "udp"
+    cidr_blocks = "${var.internal_subnets}"
+  }
+
+  ingress {
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "tcp"
+    cidr_blocks = "${var.internal_subnets}"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  vpc_id = "${aws_vpc.main.id}"
+}
+
+resource "aws_instance" "nat_instance" {
+  # Create these only if using NAT instances, vs. the NAT gateway service.
+  count             = "${(0 + var.use_nat_instances) * length(var.internal_subnets)}"
+  availability_zone = "${element(var.availability_zones, count.index)}"
+
+  tags {
+    Name        = "${var.name}-${format("internal-%03d NAT", count.index+1)}"
+    Environment = "${var.environment}"
+  }
+
+  volume_tags {
+    Name        = "${var.name}-${format("internal-%03d NAT", count.index+1)}"
+    Environment = "${var.environment}"
+  }
+
+  key_name                    = "${var.nat_instance_ssh_key_name}"
+  ami                         = "${data.aws_ami.nat_ami.id}"
+  instance_type               = "${var.nat_instance_type}"
+  source_dest_check           = false
+  associate_public_ip_address = true
+  subnet_id                   = "${element(aws_subnet.external.*.id, count.index)}"
+  vpc_security_group_ids      = ["${aws_security_group.nat_instances.id}"]
+}
+
+resource "aws_eip_association" "nat_instance_eip" {
+  # Create these only if using NAT instances, vs. the NAT gateway service.
+  count         = "${(0 + (var.use_nat_instances * var.use_eip_with_nat_instances)) * length(var.internal_subnets)}"
+  instance_id   = "${element(aws_instance.nat_instance.*.id, count.index)}"
+  allocation_id = "${element(aws_eip.nat.*.id, count.index)}"
 }
 
 /**
@@ -125,10 +226,18 @@ resource "aws_route_table" "internal" {
 }
 
 resource "aws_route" "internal" {
-  count                  = "${length(compact(var.internal_subnets))}"
+  # Create this only if using the NAT gateway service, vs. NAT instances.
+  count                  = "${(1 - var.use_nat_instances) * length(compact(var.internal_subnets))}"
   route_table_id         = "${element(aws_route_table.internal.*.id, count.index)}"
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = "${element(aws_nat_gateway.main.*.id, count.index)}"
+}
+
+resource "aws_route" "internal_nat_instance" {
+  count                  = "${(0 + var.use_nat_instances) * length(compact(var.internal_subnets))}"
+  route_table_id         = "${element(aws_route_table.internal.*.id, count.index)}"
+  destination_cidr_block = "0.0.0.0/0"
+  instance_id            = "${element(aws_instance.nat_instance.*.id, count.index)}"
 }
 
 /**


### PR DESCRIPTION
IF NAT instances are used, optional inputs are whether to use Elastic
IPs, an SSH key name, and the EC2 instance type. The latest Amazon VPC
NAT AMI is used. The use of NAT instances can be less expensive than NAT
gateways for development VPCs. NAT instances can be stopped when not in
use.