### PR TITLE
Enhance retrieving of elb_account in s3_logs module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -230,7 +230,6 @@ module "s3_logs" {
   source                  = "./s3-logs"
   name                    = "${var.name}"
   environment             = "${var.environment}"
-  account_id              = "${module.defaults.s3_logs_account_id}"
   logs_expiration_enabled = "${var.logs_expiration_enabled}"
   logs_expiration_days    = "${var.logs_expiration_days}"
 }

--- a/s3-logs/main.tf
+++ b/s3-logs/main.tf
@@ -4,9 +4,6 @@ variable "name" {
 variable "environment" {
 }
 
-variable "account_id" {
-}
-
 variable "logs_expiration_enabled" {
   default = false
 }
@@ -15,12 +12,14 @@ variable "logs_expiration_days" {
   default = 30
 }
 
+data "aws_elb_service_account" "main" {}
+
 data "template_file" "policy" {
   template = "${file("${path.module}/policy.json")}"
 
   vars = {
     bucket     = "${var.name}-${var.environment}-logs"
-    account_id = "${var.account_id}"
+    elb_account_id = "${data.aws_elb_service_account.main.arn}"
   }
 }
 

--- a/s3-logs/policy.json
+++ b/s3-logs/policy.json
@@ -5,7 +5,7 @@
       "Action": "s3:PutObject",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "arn:aws:iam::${account_id}:root"
+        "AWS": "${elb_account_id}"
       },
       "Resource": "arn:aws:s3:::${bucket}/*",
       "Sid": "log-bucket-policy"


### PR DESCRIPTION
Rather than having a hardcoded table in defaults module. This is a more convenient way of getting elb_accounts_id.
However, the data source used here was added in [version 0.7.1 ](https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md#071-august-19-2016) so, bear in mind.