### PR TITLE
variable to override allow_major_version_upgrade

### DIFF
--- a/rds/main.tf
+++ b/rds/main.tf
@@ -66,6 +66,11 @@ variable "apply_immediately" {
   default     = true
 }
 
+variable "allow_major_version_upgrade" {
+  description = "If true, major version upgrades are allowed"
+  default     = false
+}
+
 variable "instance_class" {
   description = "Underlying instance type"
   default     = "db.t2.micro"
@@ -148,12 +153,13 @@ resource "aws_db_instance" "main" {
   identifier = "${var.name}"
 
   # Database
-  engine         = "${var.engine}"
-  engine_version = "${var.engine_version}"
-  username       = "${coalesce(var.username, var.name)}"
-  password       = "${var.password}"
-  multi_az       = "${var.multi_az}"
-  name           = "${coalesce(var.database, var.name)}"
+  engine                      = "${var.engine}"
+  engine_version              = "${var.engine_version}"
+  allow_major_version_upgrade = "${var.allow_major_version_upgrade}"
+  username                    = "${coalesce(var.username, var.name)}"
+  password                    = "${var.password}"
+  multi_az                    = "${var.multi_az}"
+  name                        = "${coalesce(var.database, var.name)}"
 
   # Backups / maintenance
   backup_retention_period   = "${var.backup_retention_period}"


### PR DESCRIPTION
The current latest `engine_version` on AWS is 10.x but the default in the `rds` module, is still on 9x. This change will allow one to upgrade major versions if they had initialized and created a db instance with the defaults. 

The `allow_major_version_upgrade` is optional in terraform, so this will cause a state modification but with the default as `false`, the functionality is still the same and should be backwards compatible.